### PR TITLE
add https://jitpack.io/#drieks/antlr-kotlin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ repositories {
 }
 ```
 
-Add the dependency to `kotlinx.ast` into your project:
+Add the dependency to `kotlinx.ast` into your project (latest version string is listed [here](https://jitpack.io/#drieks/antlr-kotlin)):
 ```
 kotlin {
     jvm()


### PR DESCRIPTION
It was mentioned, but was not clickable

BTW, https://github.com/kotlinx/ast/releases mentions that the first release happened - maybe using releases now is recommended?