### PR TITLE
GRADLE_METADATA is not required for Gradle 5.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ There is a small example to get started:
 ## Using with Gradle
 `kotlinx.ast` is accessible on Maven & Gradle through Jitpack. In Jitpack basically you can use every commit or tag as a version number. You can find recent versions on the Jitpack page for `kotlinx.ast`.
 
-You have to add this line to `settings.gradle.kts`: (otherwise, the jars are not resolved):
+You have to add this line to `settings.gradle.kts` if use Gradle lower than 5.3: (otherwise, the jars are not resolved):
 ```
 // Enables KotlinMultiplatform publication and resolving (in dependencies)
 enableFeaturePreview("GRADLE_METADATA")


### PR DESCRIPTION
WARNING: this is not tested and depends on https://blog.gradle.org/gradle-metadata-1.0 and may be wrong!

> Starting with Gradle 5.3, if you are a consumer and the library you use has Gradle metadata published, Gradle will automatically consume any Gradle metadata that is published to Maven or Ivy repositories.

https://blog.gradle.org/gradle-metadata-1.0